### PR TITLE
[Feature] 시장 조사(3),(4) 기능 구현 - (트렌드, 주요 고객, 기술 동향 조회), (시장조사 이력 저장)

### DIFF
--- a/src/main/java/org/jiwoo/back/marketresearch/aggregate/vo/ResponseTrendCustomerTechnologyVO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/aggregate/vo/ResponseTrendCustomerTechnologyVO.java
@@ -1,0 +1,16 @@
+package org.jiwoo.back.marketresearch.aggregate.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jiwoo.back.marketresearch.dto.TrendCustomerTechnologyDTO;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseTrendCustomerTechnologyVO {
+    private String message;
+    private TrendCustomerTechnologyDTO data;
+}

--- a/src/main/java/org/jiwoo/back/marketresearch/controller/MarketResearchController.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/controller/MarketResearchController.java
@@ -2,14 +2,19 @@ package org.jiwoo.back.marketresearch.controller;
 
 import org.jiwoo.back.marketresearch.aggregate.vo.ResponseSimilarVO;
 import org.jiwoo.back.marketresearch.aggregate.vo.ResponseTrendCustomerTechnologyVO;
+import org.jiwoo.back.marketresearch.dto.MarketResearchHistoryDTO;
 import org.jiwoo.back.marketresearch.dto.SimilarServicesAnalysisDTO;
 import org.jiwoo.back.marketresearch.dto.TrendCustomerTechnologyDTO;
 import org.jiwoo.back.marketresearch.service.MarketResearchService;
 import org.jiwoo.back.marketresearch.dto.MarketSizeGrowthDTO;
 import org.jiwoo.back.marketresearch.aggregate.vo.ResponseMarketResearchVO;
 import org.jiwoo.back.business.dto.BusinessDTO;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @RestController
 @RequestMapping("/market-research")
@@ -23,42 +28,45 @@ public class MarketResearchController {
 
     /* 설명. 사업 정보 기반 시장규모, 성장률 조회 */
     @PostMapping("/market-size-growth")
-    public ResponseEntity<ResponseMarketResearchVO> getMarketSizeAndGrowth(@RequestBody BusinessDTO businessDTO) {
-        try {
-            MarketSizeGrowthDTO result = marketResearchService.getMarketSizeAndGrowth(businessDTO);
-            ResponseMarketResearchVO response = new ResponseMarketResearchVO("조회 성공", result);
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            ResponseMarketResearchVO errorResponse = new ResponseMarketResearchVO("조회 실패: " + e.getMessage(), null);
-            return ResponseEntity.badRequest().body(errorResponse);
-        }
+    public ResponseEntity<?> getMarketSizeAndGrowth(@RequestBody BusinessDTO businessDTO) {
+        return executeMarketResearch(businessDTO, marketResearchService::getMarketSizeAndGrowth, ResponseMarketResearchVO::new);
     }
 
     /* 설명. 유사 서비스 분석 조회 */
     @PostMapping("/similar-services-analysis")
-    public ResponseEntity<ResponseSimilarVO> getSimilarServicesAnalysis(@RequestBody BusinessDTO businessDTO) {
-        try {
-            SimilarServicesAnalysisDTO result = marketResearchService.analyzeSimilarServices(businessDTO);
-            ResponseSimilarVO response = new ResponseSimilarVO("분석 성공", result);
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            ResponseSimilarVO errorResponse = new ResponseSimilarVO("분석 실패: " + e.getMessage(), null);
-            return ResponseEntity.badRequest().body(errorResponse);
-        }
+    public ResponseEntity<?> getSimilarServicesAnalysis(@RequestBody BusinessDTO businessDTO) {
+        return executeMarketResearch(businessDTO, marketResearchService::analyzeSimilarServices, ResponseSimilarVO::new);
     }
 
     /* 설명. 사업 정보 기반 트렌드, 연령층별 고객분포, 기술 동향 조회 */
     @PostMapping("/trend-customer-technology")
-    public ResponseEntity<ResponseTrendCustomerTechnologyVO> getTrendCustomerTechnology(@RequestBody BusinessDTO businessDTO) {
+    public ResponseEntity<?> getTrendCustomerTechnology(@RequestBody BusinessDTO businessDTO) {
+        return executeMarketResearch(businessDTO, marketResearchService::getTrendCustomerTechnology, ResponseTrendCustomerTechnologyVO::new);
+    }
+
+    private <T, R> ResponseEntity<?> executeMarketResearch(BusinessDTO businessDTO,
+                                                           Function<BusinessDTO, T> serviceMethod,
+                                                           BiFunction<String, T, R> responseConstructor) {
         try {
-            TrendCustomerTechnologyDTO result = marketResearchService.getTrendCustomerTechnology(businessDTO);
-            ResponseTrendCustomerTechnologyVO response = new ResponseTrendCustomerTechnologyVO("조회 성공", result);
+            T result = serviceMethod.apply(businessDTO);
+            R response = responseConstructor.apply("조회 성공", result);
             return ResponseEntity.ok(response);
         } catch (RuntimeException e) {
-            ResponseTrendCustomerTechnologyVO errorResponse = new ResponseTrendCustomerTechnologyVO("조회 실패: " + e.getMessage(), null);
+            R errorResponse = responseConstructor.apply("조회 실패: " + e.getMessage(), null);
             return ResponseEntity.badRequest().body(errorResponse);
         }
     }
 
-
+    /* 설명. 시장 조회 이력 저장 */
+    @PostMapping("/save-history")
+    public ResponseEntity<String> saveMarketResearchHistory(@RequestBody MarketResearchHistoryDTO historyDTO) {
+        try {
+            marketResearchService.saveMarketResearchHistory(historyDTO);
+            return ResponseEntity.ok("조회 이력 저장 성공");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("조회 이력 저장 실패: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("조회 이력 저장 실패: 내부 서버 오류");
+        }
+    }
 }

--- a/src/main/java/org/jiwoo/back/marketresearch/controller/MarketResearchController.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/controller/MarketResearchController.java
@@ -1,7 +1,9 @@
 package org.jiwoo.back.marketresearch.controller;
 
 import org.jiwoo.back.marketresearch.aggregate.vo.ResponseSimilarVO;
+import org.jiwoo.back.marketresearch.aggregate.vo.ResponseTrendCustomerTechnologyVO;
 import org.jiwoo.back.marketresearch.dto.SimilarServicesAnalysisDTO;
+import org.jiwoo.back.marketresearch.dto.TrendCustomerTechnologyDTO;
 import org.jiwoo.back.marketresearch.service.MarketResearchService;
 import org.jiwoo.back.marketresearch.dto.MarketSizeGrowthDTO;
 import org.jiwoo.back.marketresearch.aggregate.vo.ResponseMarketResearchVO;
@@ -44,4 +46,19 @@ public class MarketResearchController {
             return ResponseEntity.badRequest().body(errorResponse);
         }
     }
+
+    /* 설명. 사업 정보 기반 트렌드, 연령층별 고객분포, 기술 동향 조회 */
+    @PostMapping("/trend-customer-technology")
+    public ResponseEntity<ResponseTrendCustomerTechnologyVO> getTrendCustomerTechnology(@RequestBody BusinessDTO businessDTO) {
+        try {
+            TrendCustomerTechnologyDTO result = marketResearchService.getTrendCustomerTechnology(businessDTO);
+            ResponseTrendCustomerTechnologyVO response = new ResponseTrendCustomerTechnologyVO("조회 성공", result);
+            return ResponseEntity.ok(response);
+        } catch (RuntimeException e) {
+            ResponseTrendCustomerTechnologyVO errorResponse = new ResponseTrendCustomerTechnologyVO("조회 실패: " + e.getMessage(), null);
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+
+
 }

--- a/src/main/java/org/jiwoo/back/marketresearch/dto/MarketResearchHistoryDTO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/dto/MarketResearchHistoryDTO.java
@@ -1,0 +1,19 @@
+package org.jiwoo.back.marketresearch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketResearchHistoryDTO {
+    private String marketInformation;
+    private String competitorAnalysis;
+    private String marketTrends;
+    private String regulationInformation;
+    private String marketEntryStrategy;
+    private int businessId;
+}

--- a/src/main/java/org/jiwoo/back/marketresearch/dto/MarketSizeGrowthDTO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/dto/MarketSizeGrowthDTO.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MarketSizeGrowthDTO {
+    private int businessId;
     private String marketSize;
     private String growthRate;
 }

--- a/src/main/java/org/jiwoo/back/marketresearch/dto/SimilarServicesAnalysisDTO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/dto/SimilarServicesAnalysisDTO.java
@@ -12,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SimilarServicesAnalysisDTO {
+    private int businessId;
     private List<String> similarServices;
     private String analysis;
 }

--- a/src/main/java/org/jiwoo/back/marketresearch/dto/TrendCustomerTechnologyDTO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/dto/TrendCustomerTechnologyDTO.java
@@ -1,0 +1,16 @@
+package org.jiwoo.back.marketresearch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrendCustomerTechnologyDTO {
+    private String trend;
+    private String mainCustomers;
+    private String technologyTrend;
+}

--- a/src/main/java/org/jiwoo/back/marketresearch/dto/TrendCustomerTechnologyDTO.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/dto/TrendCustomerTechnologyDTO.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TrendCustomerTechnologyDTO {
+    private int businessId;
     private String trend;
     private String mainCustomers;
     private String technologyTrend;

--- a/src/main/java/org/jiwoo/back/marketresearch/service/MarketResearchService.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/service/MarketResearchService.java
@@ -1,6 +1,7 @@
 package org.jiwoo.back.marketresearch.service;
 
 import org.jiwoo.back.business.dto.BusinessDTO;
+import org.jiwoo.back.marketresearch.dto.MarketResearchHistoryDTO;
 import org.jiwoo.back.marketresearch.dto.MarketSizeGrowthDTO;
 import org.jiwoo.back.marketresearch.dto.SimilarServicesAnalysisDTO;
 import org.jiwoo.back.marketresearch.dto.TrendCustomerTechnologyDTO;
@@ -9,4 +10,5 @@ public interface MarketResearchService {
     MarketSizeGrowthDTO getMarketSizeAndGrowth(BusinessDTO businessDTO);
     SimilarServicesAnalysisDTO analyzeSimilarServices(BusinessDTO businessDTO);
     TrendCustomerTechnologyDTO getTrendCustomerTechnology(BusinessDTO businessDTO);
+    void saveMarketResearchHistory(MarketResearchHistoryDTO historyDTO);
 }

--- a/src/main/java/org/jiwoo/back/marketresearch/service/MarketResearchService.java
+++ b/src/main/java/org/jiwoo/back/marketresearch/service/MarketResearchService.java
@@ -3,8 +3,10 @@ package org.jiwoo.back.marketresearch.service;
 import org.jiwoo.back.business.dto.BusinessDTO;
 import org.jiwoo.back.marketresearch.dto.MarketSizeGrowthDTO;
 import org.jiwoo.back.marketresearch.dto.SimilarServicesAnalysisDTO;
+import org.jiwoo.back.marketresearch.dto.TrendCustomerTechnologyDTO;
 
 public interface MarketResearchService {
     MarketSizeGrowthDTO getMarketSizeAndGrowth(BusinessDTO businessDTO);
     SimilarServicesAnalysisDTO analyzeSimilarServices(BusinessDTO businessDTO);
+    TrendCustomerTechnologyDTO getTrendCustomerTechnology(BusinessDTO businessDTO);
 }


### PR DESCRIPTION
### 🧑‍💻PR 타입(하나 이상의 PR 타입을 선택해주세요)🧑‍💻
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 및 구조 개선

### 반영 브랜치🥞
ex) feat/market_research -> dev

### 변경 사항🧐
- 시장조사 기능 중 트렌드, 주요 고객, 기술 동향을 조회하는 기능을 구현하였습니다.
- 시장조사 이력 저장 기능을 구현하였습니다.
- 이력저장 시 사업ID를 위해 각 DTO에 사업ID도 함께 반환하도록 하였습니다.

### 테스트 결과🔖
<img width="309" alt="스크린샷 2024-07-31 오후 12 26 21" src="https://github.com/user-attachments/assets/b1a93089-b1f9-437a-833b-a0ebdfea35e2">

<img width="275" alt="스크린샷 2024-07-31 오후 2 39 12" src="https://github.com/user-attachments/assets/080fa2d6-9970-4487-9772-216f8fb1a2be">

### 관련 이슈
- Resolve: AI-Jiwoo/Jiwoo#6


